### PR TITLE
Fix footer map issue after deployment

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -51,10 +51,6 @@ const nextConfig = {
           value: 'max-age=31536000; includeSubDomains'
         },
         {
-          key: 'X-Frame-Options',
-          value: 'SAMEORIGIN'
-        },
-        {
           key: 'X-Content-Type-Options',
           value: 'nosniff'
         },

--- a/vercel.json
+++ b/vercel.json
@@ -14,7 +14,7 @@
         },
         {
           "key": "X-Frame-Options",
-          "value": "DENY"
+          "value": "SAMEORIGIN"
         },
         {
           "key": "X-XSS-Protection",
@@ -26,7 +26,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://www.google-analytics.com;"
+          "value": "default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://www.google-analytics.com; frame-src 'self' https://www.google.com https://maps.google.com;"
         }
       ]
     },


### PR DESCRIPTION
<!-- Configure security headers to allow Google Maps iframe on Vercel deployment. -->

<!-- The Google Maps iframe was blocked due to `X-Frame-Options: DENY` in `vercel.json` and an incomplete Content Security Policy. This PR updates `vercel.json` to use `SAMEORIGIN` for `X-Frame-Options` and adds Google Maps domains to the `frame-src` directive of the CSP. It also removes a redundant `X-Frame-Options` header from `next.config.mjs` to prevent conflicts. -->